### PR TITLE
Implementar un servicio básico con endpoint /salud y agregar un Makefile inicial

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+.PHONY: build clean format help lint pack run test tools
+
+# Directorios
+SRC_DIR := src
+TST_DIR := tests
+OUT_DIR := out
+DST_DIR := dist
+
+# Variables de entorno
+PORT ?= 8080
+RELEASE ?= 0.1.0-alpha
+LOG_LEVEL ?= info
+
+# Targets
+tools: ## Verificar disponibilidad de dependencias
+	@echo "Verificando herramientas"
+	@command -v bash > /dev/null 2>&1 || { echo "Comando no encontrado: bash"; exit 1; }
+	@command -v bats > /dev/null 2>&1 || { echo "Comando no encontrado: bats"; exit 1; }
+	@command -v curl > /dev/null 2>&1 || { echo "Comando no encontrado: curl"; exit 1; }
+	@command -v nc > /dev/null 2>&1 || { echo "Comando no encontrado: nc"; exit 1; }
+	@command -v ss > /dev/null 2>&1 || { echo "Comando no encontrado: ss"; exit 1; }
+
+lint: ## Revisar formato de Bash scripts
+	
+
+format: ## Formatear Bash scripts
+	
+
+build: tools ## Prepara artefactos intermedios en out/
+	
+
+test: build ## Ejecutar suite de pruebas Bats
+	
+
+run: build ## Ejecutar el pipeline principal
+	
+
+pack: build test ## Generar paquete reproducible en dist/
+	
+
+clean: ## Limpiar directorios out/ y dist/
+	@echo "Limpiando artefactos"
+	@rm -rf $(OUT_DIR) $(DST_DIR)
+
+help: ## Mostrar lista de targets
+	@echo "Targets disponibles:"
+	@grep -E '^[a-zA-Z0-9_\-]+:.*?##' $(MAKEFILE_LIST) | \
+		awk 'BEGIN{FS=":.*?##"}{printf "  \033[36m%-22s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 # Configuración inicial
 SHELL := /bin/bash
+SHELLCHECK := shellcheck
+SHFMT := shfmt
 
 MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
 
@@ -30,14 +32,22 @@ tools: ## Verificar disponibilidad de dependencias
 	@command -v bash > /dev/null 2>&1 || { echo "Comando no encontrado: bash"; exit 1; }
 	@command -v bats > /dev/null 2>&1 || { echo "Comando no encontrado: bats"; exit 1; }
 	@command -v curl > /dev/null 2>&1 || { echo "Comando no encontrado: curl"; exit 1; }
+	@command -v find > /dev/null 2>&1 || { echo "Comando no encontrado: find"; exit 1; }
 	@command -v nc > /dev/null 2>&1 || { echo "Comando no encontrado: nc"; exit 1; }
 	@command -v ss > /dev/null 2>&1 || { echo "Comando no encontrado: ss"; exit 1; }
 
 lint: ## Revisar formato de Bash scripts
-	
+	@find $(SRC_DIR) -name "*.sh" -type f | while read -r file; do \
+		echo "Revisando $$file"; \
+		$(SHELLCHECK) "$$file" || exit 1; \
+		$(SHFMT) -d "$$file" || exit 1; \
+	done
 
 format: ## Formatear Bash scripts
-	
+	@find $(SRC_DIR) -name "*.sh" -type f | while read -r file; do \
+		echo "Formateando $$file"; \
+		$(SHFMT) -w "$$file" || exit 1; \
+	done
 
 build: tools ## Prepara artefactos intermedios en out/
 	

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,16 @@
+# Configuración inicial
+SHELL := /bin/bash
+
+MAKEFLAGS += --warn-undefined-variables --no-builtin-rules
+
+.DEFAULT_GOAL := help
+.SHELLFLAGS := -eu -o pipefail -c
+.DELETE_ON_ERROR:
+
+export LC_ALL := C
+export LANG := C
+export TZ := UTC
+
 .PHONY: build clean format help lint pack run test tools
 
 # Directorios

--- a/docs/bitacora-sprint-1.md
+++ b/docs/bitacora-sprint-1.md
@@ -1,0 +1,56 @@
+# Bitácora Sprint 1 - Pipeline "Build-Release-Run" con artefacto firmado
+
+## Objetivo del Sprint
+Establecer el codebase, implementar un servicio mínimo con un endpoint /salud y agregar un Makefile inicial con la estructura de los targets. Además, agregar una prueba Bats representativa.
+
+## Comandos Ejecutados y Resultados
+
+### 1. Inicio del servidor
+```bash
+./src/server.sh 
+```
+**Salida:**
+```
+Iniciando servidor en 127.0.0.1:8080
+Esperando conexión
+```
+
+### 2. Lectura del endpoint /salud
+```bash
+curl http://127.0.0.1:8080/salud
+```
+**Salida:**
+```
+{
+    "status": "OK",
+    "timestamp": "2025-09-27T23:42:22Z",
+    "uptime_seconds": 29 
+}
+```
+
+### 3. Manejo de otros endpoints
+```bash
+curl http://127.0.0.1:8080/otro
+```
+**Salida:**
+```
+{
+    "error": "Not Found"
+    "message": "Endpoint /otro no encontrado"
+    "timestamp": "2025-09-27T23:44:00Z"
+}
+```
+
+## Decisiones Técnicas Tomadas
+
+### Estructura de Directorios
+- **Decisión:** Separación de directorios en source (`src/`), tests (`tests/`), salidas (`out/`) y distribución (`dist/`)
+- **Razón:** Organización estándar que facilita automatización y empaquetado
+
+### Variables de Entorno
+- **Decisión:** Usar `PORT`, `HOST`, `RELEASE` y `LOG_LEVEL` como variables de entorno
+- **Razón:** Cumplimiento 12-Factor Factor III - configuración externa
+
+### Dependencias de Targets
+- **Decisión:** Cadena `tools → build → test` y `build → run`
+- **Razón:** Garantizar verificación de dependencias antes de ejecución

--- a/src/server.sh
+++ b/src/server.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 # Variables de entorno por defecto
 HOST="${HOST:-127.0.0.1}"
 PORT="${PORT:-8080}"
-SERVER_START=$(date +%s)
 
-# Variables para limpieza
+# Variables para limpieza y logging
+SERVER_START=$(date +%s)
 FIFO=""
 SERVER_PID=""
 
@@ -53,7 +53,7 @@ health_endpoint() {
 {
     "status": "OK",
     "timestamp": "$timestamp",
-    "uptime_seconds": $(($(date +%s) - SERVER_START)) 
+    "uptime_seconds": $(($(date +%s) - SERVER_START)),
 }
 EOF
     )
@@ -70,9 +70,9 @@ not_found_endpoint() {
     local json_response
     json_response=$(cat << EOF
 {
-    "error": "Not Found"
-    "message": "Endpoint $path no encontrado"
-    "timestamp": "$timestamp"
+    "error": "Not Found",
+    "message": "Endpoint $path no encontrado",
+    "timestamp": "$timestamp",
 }
 EOF
     )
@@ -125,7 +125,7 @@ start_server() {
     while true; do
         echo "Esperando conexión" >&2
         
-        nc -l $HOST $PORT < "$FIFO" | (
+        nc -l "$HOST" "$PORT" < "$FIFO" | (
             process_request > "$FIFO"
         )
     done

--- a/src/server.sh
+++ b/src/server.sh
@@ -125,7 +125,7 @@ start_server() {
     while true; do
         echo "Esperando conexión" >&2
         
-        nc -l -s "$HOST" -p "$PORT" < "$FIFO" | (
+        nc -l $HOST $PORT < "$FIFO" | (
             process_request > "$FIFO"
         )
     done

--- a/src/server.sh
+++ b/src/server.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Variables de entorno por defecto
+HOST="${HOST:-127.0.0.1}"
+PORT="${PORT:-8080}"
+SERVER_START=$(date +%s)
+
+# Generar respuesta HTTP
+generate_response() {
+    local status_code="$1"
+    local content="$2"
+    local content_type="${3:-application/json}"
+
+    cat << EOF
+HTTP/1.1 $status_code
+Content-Type: $content_type
+Content-Length: ${#content}
+Connection: close
+
+$content
+
+EOF
+}
+
+# Endpoint /salud
+health_endpoint() {
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    local json_response
+    json_response=$(cat << EOF
+{
+    "status": "OK",
+    "timestamp": "$timestamp",
+    "uptime_seconds": $(($(date +%s) - SERVER_START)) 
+}
+EOF
+    )
+
+    generate_response "200 OK" "$json_response"
+}
+
+# Endpoint 404
+not_found_endpoint() {
+    local path="$1"
+    local timestamp
+    timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    
+    local json_response
+    json_response=$(cat << EOF
+{
+    "error": "Not Found"
+    "message": "Endpoint $path no encontrado"
+    "timestamp": "$timestamp"
+}
+EOF
+    )
+
+    generate_response "404 Not Found" "$json_response"
+}
+
+# Procesar request HTTP
+process_request() {
+    local request_line
+    read -r request_line || return 1
+
+    while read -r header; do
+        [[ -z "$header" || "$header" == $'\r' ]] && break
+    done
+
+    local method path protocol
+    read -r method path protocol <<< "$request_line"
+
+    echo "Procesando request: $method $path" >&2
+
+    case "$path" in
+        "/salud"|"/salud/")
+            if [[ "$method" == "GET" ]]; then
+                health_endpoint
+            else
+                generate_response "405 Method Not Allowed" '{"error":"Method Not Allowed"}'
+            fi
+            ;;
+        *)
+            not_found_endpoint "$path"
+            ;;
+    esac
+}
+
+start_server() {
+    echo "Iniciando servidor en $HOST:$PORT" >&2
+
+    # Verificar que el puerto no esté en uso
+    if nc -z "$HOST" "$PORT" 2>/dev/null; then
+        echo "Error: Puerto $PORT se encuentra en uso en $HOST" >&2
+        exit 2
+    fi
+
+    # Crear FIFO
+    local fifo=$(mktemp -u)
+    mkfifo "$fifo"
+    trap "rm -f '$fifo'" EXIT
+
+    # Servidor principal
+    while true; do
+        echo "Esperando conexión" >&2
+        
+        nc -l -s "$HOST" -p "$PORT" < "$fifo" | (
+            process_request > "$fifo"
+        )
+    done
+}
+
+main() {
+    start_server
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi


### PR DESCRIPTION
**Qué:** Se inicia un servidor robusto con un endpoint /salud mediante un script `.sh`. Además se agrega un Makefile inicial con la estructura básica de los targets necesarios para el proyecto.
**Por qué:** Con el servidor inicial, se puede iniciar la fase de pruebas con Bats y de manera automatizada gracias al Makefile.
**Cómo:** Creación de `src/server.sh` inicia el servidor que escucha requests en el endpoint /salud. 

**Evidencia:** El servicio envía exitosamente el mensaje correcto cuando se solicita mediante `curl` con GET.

## Checklist de Revisión

- [x] Servicio funcional en `src/server.sh`
- [x] Makefile con targets básicos
- [x] Documentación en `docs/bitacora-sprint-1.md`
- [x] Limpieza con trap
- [x] Estructura 12-Factor: Configuración externalizada via variables de entorno